### PR TITLE
Changed default to not cache fixtures

### DIFF
--- a/src/playback-server.coffee
+++ b/src/playback-server.coffee
@@ -130,7 +130,7 @@ exports.PlaybackServer = class PlaybackServer extends events.EventEmitter
             if recordedResponse.body64
               recordedResponse.body = new Buffer(recordedResponse.body64, 'base64')
               delete recordedResponse.body64
-            @responses[filename] = recordedResponse unless @options.alwaysLoadFixtures
+            @responses[filename] = recordedResponse if @options.cacheFixtures
             @_playbackRecordedResponse req, res, recordedResponse
           catch e
             console.log "Error loading #{filename}: #{e}"


### PR DESCRIPTION
This will become a problem when the fixtures are
used for a lot of users as planned.
