### PR TITLE
Use the latest version of vows instead of 0.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "xtend": "= 1.0.3"
   },
   "devDependencies": {
-    "vows": "= 0.6.2"
+    "vows": "^0.8.1"
   },
   "scripts": {
     "test": "rm -f test/fixtures/*.response && vows --spec test/*-test.coffee",


### PR DESCRIPTION
When you run _npm test_, you'll get a similar error message as mentioned appuri/mock-http-server/issues/11. It seems like that vows causes the error, while this issue has been solved on vows' side (see vowsjs/vows/issues/230). The issue here is using an old vows for its test.

This commit substitute the latest vows, 0.8.1, with 0.6.2 that is specified in the current package.json.
